### PR TITLE
Adds NS, definitions for `autocomplete`

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,5 +1,19 @@
 import _ from 'lodash'
+import * as bitburner from "./NetscriptDefinitions";
+
+export { };
 
 declare global {
     const _: typeof _
+    
+    interface NS extends bitburner.NS {}
+
+    type AutocompleteConfig = [string, string | number | boolean | string[]][];
+
+    interface AutocompleteData {
+        servers: string[],
+        txts: string[],
+        scripts: string[],
+        flags: (config: AutocompleteConfig) => any
+    }
 }


### PR DESCRIPTION
In order to prevent `import { NS } from "@ns"` in each script, I've added it to global.
Also types for `autocomplete` are missing right now, so I added them too.