### PR TITLE
Update link to Definitions to new official repo, spelling fixes, formatting fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,7 @@
     // Autosnippet settings
     "autoSnippet.snippets": [
         {
-            "pattern": "**/*.ts", 
+            "pattern": "**/*.ts",
             "snippet": "ns-template"
         },
     ],

--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -5,7 +5,7 @@
     "body": [
       "import { NS } from '@ns'",
       "",
-      "export async function main(ns : NS) : Promise<void> {",
+      "export async function main(ns: NS): Promise<void> {",
       "\t//",
       "}"
     ]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To import `someFunction` from the file `main.ts` located in the `src/` directory
 import { someFunction } from 'main'
 ```
 
-## Deugging
+## Debugging
 
 For debugging bitburner on Steam you will need to enable a remote debugging port. This can be done by rightclicking bitburner in your Steam library and selecting properties. There you need to add `--remote-debugging-port=9222` [Thanks @DarkMio]
 

--- a/updateDefs.js
+++ b/updateDefs.js
@@ -1,7 +1,7 @@
 const https = require("https")
 const fs = require("fs")
 
-const url = 'https://raw.githubusercontent.com/danielyxie/bitburner/dev/src/ScriptEditor/NetscriptDefinitions.d.ts'
+const url = 'https://raw.githubusercontent.com/bitburner-official/bitburner-src/dev/src/ScriptEditor/NetscriptDefinitions.d.ts'
 const path = './NetscriptDefinitions.d.ts'
 
 https.get(url, (res) => {


### PR DESCRIPTION
- Removed a trailing whitespace
- Corrected the template formatting to what vscode with recommended extensions does
- Fixed the spelling mistake in the README ("Debugging" at the end)
- Updated the link for the definitions to be correct after the official repo moved